### PR TITLE
语音不中断支持

### DIFF
--- a/src/inputHook.js
+++ b/src/inputHook.js
@@ -4,6 +4,14 @@ const share = require("./share.js");
 
 var inputHistory = "";
 var playHistory = [];
+// 存放音频触发的历史记录，以便于判断是否因为tab补全而二次触发或被立刻打断，这些音频会取消或延时播放。
+// Save the history of triggered voices, so that some
+// voices that are triggered right after others can be cancelled or delayed.
+// The situation may happen especially when you use "tab" to auto-complete. 
+// example:  playHistory = [ 
+//            [ ['if'], 1650457549077 ] ,
+//            [ ['=>'], 1650457589074 ] 
+//        ]
 
 function keywordsCheck() {
     var candidate = [];
@@ -12,6 +20,7 @@ function keywordsCheck() {
         if (!voicePackage.enabled) {
             return;
         }
+        var playHistoryIsAdded = false;
         voicePackage.contributes.forEach(contribute => {
             var triggered = false;
             var keywords = [].concat(contribute.keywords || []);
@@ -29,15 +38,51 @@ function keywordsCheck() {
             if (triggered) {
                 var voices = [].concat(contribute.voices);
                 candidate.push(voicePackage.name + "/" + voices[Math.floor(voices.length * Math.random())])
-                playHistory.push([contribute, Date.now()]);
+                if (!playHistoryIsAdded) {
+                    // playHistory will add a new element first, then it will be deleted if duplicate is found.
+                    playHistory.push([contribute.keywords, Date.now()]);
+                    // One keyword may exits in many contributes.keywords. Only add once.
+                    playHistoryIsAdded = true;
+                }
             }
         });
     });
 
     if (candidate.length) {
         inputHistory = "";
-        share.play(candidate[Math.floor(Math.random() * candidate.length)]);
+        if(duplicateCheck()){
+            share.play(candidate[Math.floor(Math.random() * candidate.length)]);
+        }
+        
     }
+}
+
+
+function duplicateCheck(){
+    if (playHistory.length > 10) {
+        playHistory.shift();
+    }
+
+    if (playHistory.length == 1) {
+        return true;
+    }
+    else if (playHistory[playHistory.length - 1][1] - playHistory[playHistory.length - 2][1] <= 1000) {
+        console.log("Two voices triggered in %i milliseconds, so the latter one is cancelled.",
+            playHistory[playHistory.length - 1][1] - playHistory[playHistory.length - 2][1]);
+        playHistory.pop();
+        return false;
+    }
+    else if (playHistory[playHistory.length - 2][0] == playHistory[playHistory.length - 1][0] 
+            && playHistory[playHistory.length - 1][1] - playHistory[playHistory.length - 2][1] <= 2000) {
+        console.log("SAME voices triggered in %i milliseconds, so the latter one is cancelled.",
+            playHistory[playHistory.length - 1][1] - playHistory[playHistory.length - 2][1]);
+        playHistory.pop();
+        return false;
+    }
+    else {
+        return true;
+    }
+    
 }
 
 module.exports = function () {

--- a/src/inputHook.js
+++ b/src/inputHook.js
@@ -3,6 +3,7 @@ const vscode = require("vscode");
 const share = require("./share.js");
 
 var inputHistory = "";
+var playHistory = [];
 
 function keywordsCheck() {
     var candidate = [];
@@ -28,6 +29,7 @@ function keywordsCheck() {
             if (triggered) {
                 var voices = [].concat(contribute.voices);
                 candidate.push(voicePackage.name + "/" + voices[Math.floor(voices.length * Math.random())])
+                playHistory.push([contribute, Date.now()]);
             }
         });
     });


### PR DESCRIPTION
自己使用的过程中发现语音播放到一半被打断的情况经常发生，尤其是当你使用tab键补全的时候，于是添加了一个检测机制，如果短时间内（目前设置的是1000ms）触发了另一个语音，就会直接取消后触发语音的播放，如果2000ms内相同语音触发，就会取消相同的语音再次触发。
虽然逻辑看起来有点绕，这是为了方便后期扩展更多功能，比如延时播放之类的。
具体可以看一下这个issue : https://github.com/bobbywyx/Kizuna_AI_rainbow_fart/issues/1
#98 